### PR TITLE
Add firmware skeleton with logging, LittleFS, and serial control

### DIFF
--- a/firmware/config.h
+++ b/firmware/config.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Configuration constants for logging
+
+// Output data rate in Hz (supports 100,200,400,1000)
+constexpr uint16_t ODR_HZ = 200;
+// Accelerometer range in g (2,4,8,16)
+constexpr uint16_t RANGE_G = 4;
+// Log file name stored in LittleFS
+constexpr const char* LOG_FILE_NAME = "/ACCLOG.BIN";
+// Serial baud rate for communication
+constexpr unsigned long SERIAL_BAUD = 921600;
+
+// LSB per g for ±4g on MPU6886 (datasheet value)
+constexpr float LSB_PER_G = 8192.0f;

--- a/firmware/fs_format.h
+++ b/firmware/fs_format.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <LittleFS.h>
+#include "config.h"
+
+// Initialize LittleFS; format if mounting fails
+inline bool fs_init() {
+    if (!LittleFS.begin(false)) {
+        return LittleFS.begin(true);
+    }
+    return true;
+}
+
+// Format LittleFS explicitly
+inline bool fs_format() {
+    return LittleFS.format();
+}
+
+// Create log file for writing; existing file will be truncated
+inline File fs_create_log() {
+    return LittleFS.open(LOG_FILE_NAME, "w");
+}

--- a/firmware/imu_mpu6886.h
+++ b/firmware/imu_mpu6886.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <Wire.h>
+#include "config.h"
+
+constexpr uint8_t MPU6886_ADDR = 0x68;
+constexpr uint8_t MPU6886_PWR_MGMT_1 = 0x6B;
+constexpr uint8_t MPU6886_SMPLRT_DIV = 0x19;
+constexpr uint8_t MPU6886_ACCEL_CONFIG = 0x1C;
+constexpr uint8_t MPU6886_ACCEL_XOUT_H = 0x3B;
+
+inline bool imu_write_reg(uint8_t reg, uint8_t val) {
+    Wire.beginTransmission(MPU6886_ADDR);
+    Wire.write(reg);
+    Wire.write(val);
+    return Wire.endTransmission() == 0;
+}
+
+inline bool imu_read_regs(uint8_t reg, uint8_t* buf, size_t len) {
+    Wire.beginTransmission(MPU6886_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    Wire.requestFrom((int)MPU6886_ADDR, (int)len);
+    for (size_t i = 0; i < len && Wire.available(); ++i) {
+        buf[i] = Wire.read();
+    }
+    return true;
+}
+
+inline bool imu_init() {
+    Wire.begin();
+    Wire.setClock(400000);
+    if (!imu_write_reg(MPU6886_PWR_MGMT_1, 0x00)) return false;
+    uint8_t div;
+    switch (ODR_HZ) {
+        case 100: div = 9; break;  // 1000/(1+div)
+        case 200: div = 4; break;
+        case 400: div = 1; break;
+        case 1000: default: div = 0; break;
+    }
+    if (!imu_write_reg(MPU6886_SMPLRT_DIV, div)) return false;
+    uint8_t range = 0;
+    switch (RANGE_G) {
+        case 2: range = 0x00; break;
+        case 4: range = 0x08; break;
+        case 8: range = 0x10; break;
+        case 16: range = 0x18; break;
+    }
+    if (!imu_write_reg(MPU6886_ACCEL_CONFIG, range)) return false;
+    return true;
+}
+
+inline bool imu_read_accel_raw(int16_t& ax, int16_t& ay, int16_t& az) {
+    uint8_t buf[6];
+    if (!imu_read_regs(MPU6886_ACCEL_XOUT_H, buf, 6)) return false;
+    ax = (int16_t)((buf[0] << 8) | buf[1]);
+    ay = (int16_t)((buf[2] << 8) | buf[3]);
+    az = (int16_t)((buf[4] << 8) | buf[5]);
+    return true;
+}

--- a/firmware/m5_multi_acc_logger.ino
+++ b/firmware/m5_multi_acc_logger.ino
@@ -1,0 +1,122 @@
+#include <M5StickCPlus.h>
+#include <LittleFS.h>
+#include "config.h"
+#include "fs_format.h"
+#include "imu_mpu6886.h"
+
+bool recording = false;
+File logFile;
+static uint8_t ring_buf[4096];
+static size_t ring_pos = 0;
+static uint32_t total_samples = 0;
+
+// forward declaration for serial protocol
+void start_logging();
+void stop_logging();
+#include "serial_proto.h"
+
+struct LogHeader {
+    char magic[8];
+    uint16_t format_ver;
+    uint64_t device_uid;
+    uint64_t start_unix_ms;
+    uint16_t odr_hz;
+    uint16_t range_g;
+    uint32_t total_samples;
+    uint32_t dropped_samples;
+    uint8_t reserved[64 - 8 - 2 - 8 - 8 - 2 - 2 - 4 - 4];
+};
+
+void lcd_show_state() {
+    if (recording) {
+        M5.Lcd.fillScreen(TFT_RED);
+        M5.Lcd.setCursor(0, 0);
+        M5.Lcd.setTextColor(TFT_WHITE);
+        M5.Lcd.print("REC");
+    } else {
+        M5.Lcd.fillScreen(TFT_BLACK);
+        M5.Lcd.setCursor(0, 0);
+        M5.Lcd.setTextColor(TFT_WHITE);
+        M5.Lcd.print("IDLE");
+    }
+}
+
+void start_logging() {
+    logFile = fs_create_log();
+    if (!logFile) return;
+    LogHeader hdr = {};
+    memcpy(hdr.magic, "ACCLOG\0", 7);
+    hdr.format_ver = 0x0100;
+    hdr.device_uid = ESP.getEfuseMac();
+    hdr.start_unix_ms = 0;
+    hdr.odr_hz = ODR_HZ;
+    hdr.range_g = RANGE_G;
+    hdr.total_samples = 0xFFFFFFFF;
+    hdr.dropped_samples = 0;
+    logFile.write(reinterpret_cast<uint8_t*>(&hdr), sizeof(hdr));
+    ring_pos = 0;
+    total_samples = 0;
+    recording = true;
+    lcd_show_state();
+}
+
+void stop_logging() {
+    if (!recording) return;
+    if (ring_pos > 0) {
+        logFile.write(ring_buf, ring_pos);
+        ring_pos = 0;
+    }
+    if (logFile) {
+        logFile.flush();
+        LogHeader hdr;
+        logFile.seek(0);
+        logFile.read(reinterpret_cast<uint8_t*>(&hdr), sizeof(hdr));
+        hdr.total_samples = total_samples;
+        logFile.seek(0);
+        logFile.write(reinterpret_cast<uint8_t*>(&hdr), sizeof(hdr));
+        logFile.close();
+    }
+    recording = false;
+    lcd_show_state();
+}
+
+void setup() {
+    M5.begin();
+    M5.Lcd.setRotation(3);
+    Serial.begin(SERIAL_BAUD);
+    fs_init();
+    imu_init();
+    lcd_show_state();
+}
+
+void loop() {
+    M5.update();
+    if (M5.BtnA.wasPressed()) {
+        if (recording) stop_logging();
+        else start_logging();
+    }
+    serial_proto_poll();
+    if (!recording) {
+        delay(10);
+        return;
+    }
+
+    static uint32_t last_us = micros();
+    uint32_t now = micros();
+    if (now - last_us < (1000000UL / ODR_HZ)) return;
+    last_us += 1000000UL / ODR_HZ;
+
+    int16_t ax, ay, az;
+    if (!imu_read_accel_raw(ax, ay, az)) return;
+    ring_buf[ring_pos++] = ax >> 8;
+    ring_buf[ring_pos++] = ax & 0xFF;
+    ring_buf[ring_pos++] = ay >> 8;
+    ring_buf[ring_pos++] = ay & 0xFF;
+    ring_buf[ring_pos++] = az >> 8;
+    ring_buf[ring_pos++] = az & 0xFF;
+    total_samples++;
+    if (ring_pos >= sizeof(ring_buf)) {
+        logFile.write(ring_buf, sizeof(ring_buf));
+        ring_pos = 0;
+    }
+}

--- a/firmware/serial_proto.h
+++ b/firmware/serial_proto.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <Arduino.h>
+#include <LittleFS.h>
+#include "config.h"
+#include "fs_format.h"
+
+// start/stop functions provided by main sketch
+void start_logging();
+void stop_logging();
+extern bool recording;
+
+inline void serial_proto_poll() {
+    if (!Serial.available()) return;
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+    if (cmd == "PING") {
+        Serial.println("PONG");
+    } else if (cmd == "INFO") {
+        size_t size = 0;
+        if (LittleFS.exists(LOG_FILE_NAME)) {
+            File f = LittleFS.open(LOG_FILE_NAME, "r");
+            size = f.size();
+            f.close();
+        }
+        Serial.printf("{\"odr\":%u,\"range_g\":%u,\"file_size\":%u}\n", ODR_HZ, RANGE_G, (unsigned)size);
+    } else if (cmd == "DUMP") {
+        if (LittleFS.exists(LOG_FILE_NAME)) {
+            File f = LittleFS.open(LOG_FILE_NAME, "r");
+            size_t size = f.size();
+            Serial.printf("OK %u\n", (unsigned)size);
+            uint8_t buf[64];
+            while (f.available()) {
+                size_t n = f.read(buf, sizeof(buf));
+                Serial.write(buf, n);
+            }
+            f.close();
+            Serial.print("\nDONE\n");
+        } else {
+            Serial.println("ERR");
+        }
+    } else if (cmd == "ERASE") {
+        if (LittleFS.exists(LOG_FILE_NAME)) {
+            LittleFS.remove(LOG_FILE_NAME);
+        }
+        Serial.println("OK");
+    } else if (cmd == "START") {
+        if (!recording) start_logging();
+        Serial.println("OK");
+    } else if (cmd == "STOP") {
+        if (recording) stop_logging();
+        Serial.println("OK");
+    } else {
+        Serial.println("UNKNOWN");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement basic accelerometer logger sketch with LCD state and button start/stop
- Add configuration, LittleFS helpers, MPU6886 access, and simple serial protocol
- Support ring buffer to LittleFS and PING/INFO/DUMP/ERASE/START/STOP commands

## Testing
- `g++ -x c++ -fsyntax-only firmware/m5_multi_acc_logger.ino` *(fails: M5StickCPlus.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c649b805f08330a625292dcb7c247d