### PR TITLE
Add PC tools for M5Stick accelerometer dump

### DIFF
--- a/pc_tools/AccDumpGUI.py
+++ b/pc_tools/AccDumpGUI.py
@@ -1,0 +1,78 @@
+import threading
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+from pathlib import Path
+
+from serial_common import list_serial_ports, dump_bin
+import decoder
+
+
+class AccDumpGUI(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title('AccDumpGUI')
+        self.resizable(False, False)
+        self._build_ui()
+        self.refresh_ports()
+
+    def _build_ui(self):
+        frame = ttk.Frame(self, padding=10)
+        frame.grid(row=0, column=0)
+
+        ttk.Label(frame, text='Serial Port').grid(row=0, column=0, sticky='w')
+        self.port_var = tk.StringVar()
+        self.port_combo = ttk.Combobox(frame, textvariable=self.port_var, width=20)
+        self.port_combo.grid(row=0, column=1)
+        ttk.Button(frame, text='Refresh', command=self.refresh_ports).grid(row=0, column=2, padx=5)
+
+        self.csv_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(frame, text='CSVへ変換', variable=self.csv_var).grid(row=1, column=0, columnspan=3, sticky='w')
+
+        self.progress = ttk.Progressbar(frame, orient='horizontal', length=300)
+        self.progress.grid(row=2, column=0, columnspan=3, pady=5)
+
+        self.log = tk.Text(frame, width=50, height=10)
+        self.log.grid(row=3, column=0, columnspan=3, pady=5)
+
+        ttk.Button(frame, text='DUMP', command=self.start_dump).grid(row=4, column=0, columnspan=3)
+
+    def refresh_ports(self):
+        ports = list_serial_ports()
+        self.port_combo['values'] = ports
+        if ports:
+            self.port_combo.current(0)
+
+    def start_dump(self):
+        port = self.port_var.get()
+        if not port:
+            messagebox.showerror('Error', 'ポートを選択してください')
+            return
+        out_dir = filedialog.askdirectory(title='保存先フォルダ')
+        if not out_dir:
+            return
+        self.progress['value'] = 0
+        self.log.delete('1.0', tk.END)
+        thread = threading.Thread(target=self._dump_worker,
+                                  args=(port, Path(out_dir)),
+                                  daemon=True)
+        thread.start()
+
+    def _dump_worker(self, port: str, out_dir: Path):
+        try:
+            out_file = out_dir / 'ACCLOG.bin'
+            def cb(read_bytes, total_bytes):
+                self.progress['maximum'] = total_bytes
+                self.progress['value'] = read_bytes
+            dump_bin(port, out_file, progress_cb=cb)
+            self.log.insert(tk.END, f'DUMP完了: {out_file}\n')
+            if self.csv_var.get():
+                csv_path = out_file.with_suffix('.csv')
+                decoder.bin_to_csv(out_file, csv_path)
+                self.log.insert(tk.END, f'CSV変換完了: {csv_path}\n')
+        except Exception as e:
+            self.log.insert(tk.END, f'エラー: {e}\n')
+
+
+if __name__ == '__main__':
+    app = AccDumpGUI()
+    app.mainloop()

--- a/pc_tools/BUILD.md
+++ b/pc_tools/BUILD.md
@@ -1,0 +1,27 @@
+# Build Instructions
+
+The GUI and CLI tools are pure Python scripts. To distribute stand-alone binaries
+for Windows or macOS, [PyInstaller](https://pyinstaller.org/) is used.
+
+## Setup
+
+```bash
+python -m pip install -r requirements.txt pyinstaller
+```
+
+## Build GUI
+
+```bash
+pyinstaller --onefile --windowed AccDumpGUI.py
+```
+
+This command produces `dist/AccDumpGUI.exe` on Windows or `dist/AccDumpGUI.app`
+on macOS. Distribute the resulting file to end users.
+
+## Build CLI
+
+```bash
+pyinstaller --onefile accdump_cli.py
+```
+
+The output executable will appear under `dist/`.

--- a/pc_tools/README_AccDump.md
+++ b/pc_tools/README_AccDump.md
@@ -1,0 +1,40 @@
+# AccDump Tools
+
+PC-side utilities for extracting accelerometer logs from the M5Stick devices.
+
+## GUI Usage
+
+1. Install Python and dependencies:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+2. Run the GUI:
+   ```bash
+   python AccDumpGUI.py
+   ```
+3. Select the serial port and press **DUMP**. Choose a destination
+   directory when prompted.
+4. If *CSVへ変換* is checked, a `.csv` file will be produced next to the
+   downloaded `ACCLOG.bin`.
+
+## CLI Usage
+
+Dump from a specific port:
+
+```bash
+python accdump_cli.py --port COM5 --out logs/ --csv
+```
+
+Dump from all available ports:
+
+```bash
+python accdump_cli.py --all --out logs/
+```
+
+Convert an existing binary log:
+
+```bash
+python decoder.py ACCLOG.bin --csv
+```
+
+The CSV file contains columns `n`, `t_sec`, `ax_g`, `ay_g`, `az_g`.

--- a/pc_tools/accdump_cli.py
+++ b/pc_tools/accdump_cli.py
@@ -1,0 +1,43 @@
+import argparse
+from pathlib import Path
+
+from serial_common import list_serial_ports, dump_bin
+import decoder
+
+
+def dump_one(port: str, out_dir: Path, do_csv: bool):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / f'{port.replace("/", "_")}_ACCLOG.bin'
+    print(f'Dumping {port} -> {out_file}')
+    def cb(read_bytes, total_bytes):
+        pct = 100 * read_bytes / total_bytes if total_bytes else 0
+        print(f'\r{pct:5.1f}% ({read_bytes}/{total_bytes}B)', end='', flush=True)
+    dump_bin(port, out_file, progress_cb=cb)
+    print('\nDONE')
+    if do_csv:
+        csv_path = out_file.with_suffix('.csv')
+        decoder.bin_to_csv(out_file, csv_path)
+        print(f'CSV written: {csv_path}')
+
+
+def main():
+    p = argparse.ArgumentParser(description='M5Stick ACCLOG dumper')
+    p.add_argument('--port', help='serial port to use')
+    p.add_argument('--all', action='store_true', help='dump from all available ports')
+    p.add_argument('--out', type=Path, default=Path('.'), help='output directory')
+    p.add_argument('--csv', action='store_true', help='convert to CSV after dump')
+    args = p.parse_args()
+
+    if args.all:
+        ports = list_serial_ports()
+    elif args.port:
+        ports = [args.port]
+    else:
+        p.error('specify --port or --all')
+
+    for port in ports:
+        dump_one(port, args.out, args.csv)
+
+
+if __name__ == '__main__':
+    main()

--- a/pc_tools/decoder.py
+++ b/pc_tools/decoder.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import struct
+import numpy as np
+import pandas as pd
+
+HEADER_FMT = '<8sHQQHHII26s'
+HEADER_SIZE = struct.calcsize(HEADER_FMT)
+
+
+def parse_header(data: bytes) -> dict:
+    if len(data) < HEADER_SIZE:
+        raise ValueError('header too short')
+    (magic, fmt_ver, device_uid, start_ms, odr, range_g,
+     total_samples, dropped, _reserved) = struct.unpack(HEADER_FMT, data[:HEADER_SIZE])
+    if not magic.startswith(b'ACCLOG'):
+        raise ValueError('invalid magic')
+    return {
+        'format_ver': fmt_ver,
+        'device_uid': device_uid,
+        'start_unix_ms': start_ms,
+        'odr_hz': odr,
+        'range_g': range_g,
+        'total_samples': total_samples,
+        'dropped_samples': dropped,
+    }
+
+
+def bin_to_csv(bin_path: Path, csv_path: Path | None = None):
+    """Convert binary log file to CSV.
+
+    Returns
+    -------
+    header : dict
+        Parsed header information.
+    df : pandas.DataFrame
+        Converted dataframe with columns ``n,t_sec,ax_g,ay_g,az_g``.
+    """
+    bin_path = Path(bin_path)
+    with open(bin_path, 'rb') as f:
+        header = parse_header(f.read(HEADER_SIZE))
+        raw = np.frombuffer(f.read(), dtype='<i2')
+    data = raw.reshape(-1, 3)
+    lsb_per_g = 32768 / header['range_g']
+    acc_g = data / lsb_per_g
+    n = np.arange(len(acc_g), dtype=np.int64)
+    t_sec = n / header['odr_hz']
+    df = pd.DataFrame({'n': n, 't_sec': t_sec,
+                       'ax_g': acc_g[:, 0],
+                       'ay_g': acc_g[:, 1],
+                       'az_g': acc_g[:, 2]})
+    if csv_path:
+        df.to_csv(csv_path, index=False)
+    return header, df
+
+
+if __name__ == '__main__':
+    import argparse
+    p = argparse.ArgumentParser(description='Convert ACCLOG.BIN to CSV')
+    p.add_argument('bin_file', type=Path, help='input .bin file')
+    p.add_argument('--csv', action='store_true', help='also output CSV file')
+    args = p.parse_args()
+    out_csv = args.bin_file.with_suffix('.csv') if args.csv else None
+    header, _df = bin_to_csv(args.bin_file, out_csv)
+    for k, v in header.items():
+        print(f'{k}: {v}')
+    if out_csv:
+        print(f'CSV written: {out_csv}')

--- a/pc_tools/requirements.txt
+++ b/pc_tools/requirements.txt
@@ -1,0 +1,3 @@
+pyserial
+numpy
+pandas

--- a/pc_tools/serial_common.py
+++ b/pc_tools/serial_common.py
@@ -1,0 +1,62 @@
+import serial
+from serial.tools import list_ports
+from pathlib import Path
+
+BAUDRATE = 921600
+TIMEOUT = 5
+
+
+def list_serial_ports():
+    """Return a list of available serial port device names."""
+    return [p.device for p in list_ports.comports()]
+
+
+def open_serial(port: str):
+    """Open a serial connection with standard settings."""
+    return serial.Serial(port, BAUDRATE, timeout=TIMEOUT)
+
+
+def dump_bin(port: str, out_path: Path, progress_cb=None):
+    """Dump binary log from device connected to *port* into *out_path*.
+
+    Parameters
+    ----------
+    port : str
+        Serial port name.
+    out_path : Path
+        File path where downloaded binary will be written.
+    progress_cb : callable, optional
+        Called as ``progress_cb(read_bytes, total_bytes)`` during transfer.
+    """
+    with open_serial(port) as ser:
+        ser.reset_input_buffer()
+        ser.write(b'DUMP\n')
+        ser.flush()
+        first_line = ser.readline().decode('ascii', errors='ignore').strip()
+        if not first_line.startswith('OK'):
+            raise RuntimeError(f'Unexpected response: {first_line!r}')
+        try:
+            total = int(first_line.split()[1])
+        except Exception as exc:
+            raise RuntimeError(f'Failed to parse size from: {first_line!r}') from exc
+
+        remaining = total
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, 'wb') as f:
+            while remaining > 0:
+                chunk = ser.read(min(4096, remaining))
+                if not chunk:
+                    raise RuntimeError('Timeout while receiving data')
+                f.write(chunk)
+                remaining -= len(chunk)
+                if progress_cb:
+                    progress_cb(total - remaining, total)
+        # read trailing DONE
+        tail = ser.readline().decode('ascii', errors='ignore').strip()
+        if tail != 'DONE':
+            raise RuntimeError(f'Unexpected trailer: {tail!r}')
+        if progress_cb:
+            progress_cb(total, total)
+
+
+__all__ = ['list_serial_ports', 'open_serial', 'dump_bin']


### PR DESCRIPTION
## Summary
- Add serial communication helper to enumerate ports and dump binary logs
- Provide Tkinter GUI with DUMP action, CSV conversion, and progress bar
- Add CLI for dumping from selected or all ports with optional CSV conversion
- Implement decoder to convert binary logs to CSV with g-unit conversion
- Document requirements and build instructions for distribution

## Testing
- `python -m py_compile serial_common.py AccDumpGUI.py accdump_cli.py decoder.py`

------
https://chatgpt.com/codex/tasks/task_e_68c64aeb63248330b7c3c002b1e927bd