### PR TITLE
Use M5StickC library instead of M5StickCPlus

### DIFF
--- a/firmware/m5_multi_acc_logger.ino
+++ b/firmware/m5_multi_acc_logger.ino
@@ -1,4 +1,4 @@
-#include <M5StickCPlus.h>
+#include <M5StickC.h>
 #include <LittleFS.h>
 #include "config.h"
 #include "fs_format.h"


### PR DESCRIPTION
## Summary
- Replace `M5StickCPlus` include with `M5StickC` to target standard M5StickC hardware

## Testing
- `./bin/arduino-cli compile --fqbn esp32:esp32:m5stick-c firmware` *(fails: connect: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c64f7e8cec8330866de292f39bc27f