### PR TITLE
Handle extra newline before DONE in serial dump

### DIFF
--- a/pc_tools/serial_common.py
+++ b/pc_tools/serial_common.py
@@ -51,8 +51,11 @@ def dump_bin(port: str, out_path: Path, progress_cb=None):
                 remaining -= len(chunk)
                 if progress_cb:
                     progress_cb(total - remaining, total)
-        # read trailing DONE
+        # read trailing DONE (some firmware versions send an extra newline)
         tail = ser.readline().decode('ascii', errors='ignore').strip()
+        if not tail:
+            # consume the next line if the first read only captured a blank line
+            tail = ser.readline().decode('ascii', errors='ignore').strip()
         if tail != 'DONE':
             raise RuntimeError(f'Unexpected trailer: {tail!r}')
         if progress_cb:


### PR DESCRIPTION
## Summary
- tolerate extra newline from firmware when waiting for DONE marker

## Testing
- `python -m py_compile pc_tools/serial_common.py`
- `python pc_tools/accdump_cli.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68c65f4f39108330b58d8af5741f2e32